### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the edited image is not loaded back from disk. Instead the
 old image is possibly just tagged with the new name.
 
 By default the tool will use a local "load.tmp" temporary
-directory. You may set "-t $TMPDIR" explicitly to have it
+directory. You may set "-T $TMPDIR" explicitly to have it
 run in a normal temporary directory - but be aware that
 the archive files during save/load can be quite big and the
 tool will even unpack the archives temporarily. That's why


### PR DESCRIPTION
`-t` -> `-T` the short argument form for the temp folder location...